### PR TITLE
Added performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,10 @@ RUN apt-get update && apt-get -y upgrade && \
     git \
     yarn
 
-RUN gem install bundler
+RUN gem install bundler fast_jsonapi
 
 RUN mkdir /myapp
 WORKDIR /myapp
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
-COPY . /myapp

--- a/Gemfile
+++ b/Gemfile
@@ -5,17 +5,18 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.0'
 
+gem 'active_model_serializers', '~> 0.10.0'
+gem 'bootsnap', '>= 1.1.0', require: false
+gem 'dotenv-rails', require: 'dotenv/rails-now'
+gem 'faker'
+gem 'fast_jsonapi'
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.0'
 gem 'redis', '~> 4.0'
-
-gem 'bootsnap', '>= 1.1.0', require: false
-gem 'faker'
+gem 'searchkick'
 gem 'swagger-blocks'
 gem 'swagger_ui_engine'
-gem 'searchkick'
-gem 'active_model_serializers', '~> 0.10.0'
 
 gem 'capistrano', '~> 3.7', '>= 3.7.1'
 gem 'capistrano-rails', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,10 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     diff-lcs (1.3)
+    dotenv (2.4.0)
+    dotenv-rails (2.4.0)
+      dotenv (= 2.4.0)
+      railties (>= 3.2, < 6.0)
     elasticsearch (6.0.2)
       elasticsearch-api (= 6.0.2)
       elasticsearch-transport (= 6.0.2)
@@ -93,6 +97,8 @@ GEM
       i18n (>= 0.7)
     faraday (0.15.1)
       multipart-post (>= 1.2, < 3)
+    fast_jsonapi (1.1.1)
+      activesupport (>= 4.2)
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -235,8 +241,10 @@ DEPENDENCIES
   capistrano (~> 3.7, >= 3.7.1)
   capistrano-rails (~> 1.2)
   capistrano-rbenv (~> 2.1)
+  dotenv-rails
   factory_bot_rails
   faker
+  fast_jsonapi
   json_matchers
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -6,13 +6,18 @@ class AlbumsController < ApplicationController
 
   # GET /albums
   def index
+    @albums = Album.includes(:author, :songs)
     if params[:term].present?
-      @albums = Album.search(params[:term], limit: 10).results
+      @albums = @albums.search(params[:term], limit: results_limit).results
     else
-      @albums = Album.all
+      @albums = @albums.limit(results_limit)
     end
 
-    render json: @albums, include: [:songs]
+    options = {}.tap do |opt|
+      opt[:meta] = { total: @albums.count }
+    end
+
+    render json: AlbumSerializer.new(@albums, options).serialized_json
   end
 
   # GET /albums/1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::API
+  private
+
+  def results_limit
+    params[:limit] || 1000
+  end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -6,13 +6,18 @@ class ArtistsController < ApplicationController
 
   # GET /artists
   def index
+    @artists = Artist.includes(:bands, :songs, :albums)
     if params[:term].present?
-      @artists = Artist.search(params[:term], limit: 10).results
+      @artists = @artists.search(params[:term], limit: results_limit).results
     else
-      @artists = Artist.all
+      @artists = @artists.limit(results_limit)
     end
 
-    render json: @artists
+    options = {}.tap do |opt|
+      opt[:meta] = { total: @artists.count }
+    end
+
+    render json: ArtistSerializer.new(@artists, options).serialized_json
   end
 
   # GET /artists/1

--- a/app/controllers/bands_controller.rb
+++ b/app/controllers/bands_controller.rb
@@ -6,13 +6,18 @@ class BandsController < ApplicationController
 
   # GET /bands
   def index
+    @bands = Band.includes(:albums, :artists)
     if params[:term].present?
-      @bands = Band.search(params[:term], limit: 10).results
+      @bands = @bands.search(params[:term], limit: results_limit).results
     else
-      @bands = Band.all
+      @bands = @bands.limit(results_limit)
     end
 
-    render json: @bands
+    options = {}.tap do |opt|
+      opt[:meta] = { total: @bands.count }
+    end
+
+    render json: BandSerializer.new(@bands, options).serialized_json
   end
 
   # GET /bands/1

--- a/app/controllers/concerns/album_documentation.rb
+++ b/app/controllers/concerns/album_documentation.rb
@@ -24,7 +24,7 @@ module AlbumDocumentation
         end
       end
     end
-    swagger_path '/albums/?term={term}' do
+    swagger_path '/albums/' do
       operation :get do
         key :summary, 'Retrieve all albums'
         key :description, 'Retrieves all albums with all data attributes'
@@ -32,10 +32,17 @@ module AlbumDocumentation
         key :tags, ['album']
         parameter do
           key :name, :term
-          key :in, :path
+          key :in, :query
           key :description, 'Search Term'
           key :required, false
           key :type, :string
+        end
+        parameter do
+          key :name, :limit
+          key :in, :query
+          key :description, 'Results Limit [Default = 1000]'
+          key :required, false
+          key :type, :integer
         end
         response 200 do
           key :description, 'album response'

--- a/app/controllers/concerns/artist_documentation.rb
+++ b/app/controllers/concerns/artist_documentation.rb
@@ -24,7 +24,7 @@ module ArtistDocumentation
         end
       end
     end
-    swagger_path '/artists/?term={term}' do
+    swagger_path '/artists/' do
       operation :get do
         key :summary, 'Retrieve all artists'
         key :description, 'Retrieves all artists with all data attributes'
@@ -32,10 +32,17 @@ module ArtistDocumentation
         key :tags, ['artist']
         parameter do
           key :name, :term
-          key :in, :path
+          key :in, :query
           key :description, 'Search Term'
           key :required, false
           key :type, :string
+        end
+        parameter do
+          key :name, :limit
+          key :in, :query
+          key :description, 'Results Limit [Default = 1000]'
+          key :required, false
+          key :type, :integer
         end
         response 200 do
           key :description, 'Artist response'

--- a/app/controllers/concerns/band_documentation.rb
+++ b/app/controllers/concerns/band_documentation.rb
@@ -24,7 +24,7 @@ module BandDocumentation
         end
       end
     end
-    swagger_path '/bands/?term={term}' do
+    swagger_path '/bands/' do
       operation :get do
         key :summary, 'Retrieve all bands'
         key :description, 'Retrieves all bands with all data attributes'
@@ -32,10 +32,17 @@ module BandDocumentation
         key :tags, ['band']
         parameter do
           key :name, :term
-          key :in, :path
+          key :in, :query
           key :description, 'Search Term'
           key :required, false
           key :type, :string
+        end
+        parameter do
+          key :name, :limit
+          key :in, :query
+          key :description, 'Results Limit [Default = 1000]'
+          key :required, false
+          key :type, :integer
         end
         response 200 do
           key :description, 'Band response'

--- a/app/controllers/concerns/playlist_documentation.rb
+++ b/app/controllers/concerns/playlist_documentation.rb
@@ -24,7 +24,7 @@ module PlaylistDocumentation
         end
       end
     end
-    swagger_path '/playlists/?term={term}' do
+    swagger_path '/playlists/' do
       operation :get do
         key :summary, 'Retrieve all playlists'
         key :description, 'Retrieves all playlists with all data attributes'
@@ -32,10 +32,17 @@ module PlaylistDocumentation
         key :tags, ['playlist']
         parameter do
           key :name, :term
-          key :in, :path
+          key :in, :query
           key :description, 'Search Term'
           key :required, false
           key :type, :string
+        end
+        parameter do
+          key :name, :limit
+          key :in, :query
+          key :description, 'Results Limit [Default = 1000]'
+          key :required, false
+          key :type, :integer
         end
         response 200 do
           key :description, 'Playlist response'

--- a/app/controllers/concerns/song_documentation.rb
+++ b/app/controllers/concerns/song_documentation.rb
@@ -24,7 +24,7 @@ module SongDocumentation
         end
       end
     end
-    swagger_path '/songs/?term={term}' do
+    swagger_path '/songs/' do
       operation :get do
         key :summary, 'Retrieve all songs'
         key :description, 'Retrieves all songs with all data attributes'
@@ -32,10 +32,17 @@ module SongDocumentation
         key :tags, ['song']
         parameter do
           key :name, :term
-          key :in, :path
+          key :in, :query
           key :description, 'Search Term'
           key :required, false
           key :type, :string
+        end
+        parameter do
+          key :name, :limit
+          key :in, :query
+          key :description, 'Results Limit [Default = 1000]'
+          key :required, false
+          key :type, :integer
         end
         response 200 do
           key :description, 'Song response'

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -6,13 +6,18 @@ class PlaylistsController < ApplicationController
 
   # GET /playlists
   def index
+    @playlists = Playlist.includes(:songs)
     if params[:term].present?
-      @playlists = Playlist.search(params[:term], limit: 10).results
+      @playlists = @playlists.search(params[:term], limit: results_limit).results
     else
-      @playlists = Playlist.all
+      @playlists = @playlists.limit(results_limit)
     end
 
-    render json: @playlists
+    options = {}.tap do |opt|
+      opt[:meta] = { total: @playlists.count }
+    end
+
+    render json: PlaylistSerializer.new(@playlists, options).serialized_json
   end
 
   # GET /playlists/1

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -6,13 +6,18 @@ class SongsController < ApplicationController
 
   # GET /songs
   def index
+    @songs = Song.includes(:author, :albums, :playlists)
     if params[:term].present?
-      @songs = Song.search(params[:term], limit: 10).results
+      @songs = @songs.search(params[:term], limit: results_limit).results
     else
-      @songs = Song.all
+      @songs = @songs.limit(results_limit)
     end
 
-    render json: @songs
+    options = {}.tap do |opt|
+      opt[:meta] = { total: @songs.count }
+    end
+
+    render json: SongSerializer.new(@songs, options).serialized_json
   end
 
   # GET /songs/1

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -33,4 +33,5 @@ class Artist < ApplicationRecord
   has_many :artist_bands
   has_many :bands, through: :artist_bands, source: :artist
   has_many :songs, as: :author
+  has_many :albums, as: :author
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -39,7 +39,7 @@ class Song < ApplicationRecord
   has_many :albums, through: :album_songs, source: :album
 
   has_many :playlist_songs
-  has_many :playlist, through: :playlist_songs, source: :playlist
+  has_many :playlists, through: :playlist_songs, source: :playlist
 
   validates :name, presence: true, uniqueness: { scope: %i[author duration date] }
 end

--- a/app/serializers/album_serializer.rb
+++ b/app/serializers/album_serializer.rb
@@ -1,5 +1,8 @@
-class AlbumSerializer < ActiveModel::Serializer
+class AlbumSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :album
+  cache_options enabled: true, cache_length: 1.hour
   attributes :name, :author, :date
-  has_many :songs
-  belongs_to :author
+  has_many :songs, record_type: :song
+  belongs_to :author, polymorphic: true
 end

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -1,5 +1,9 @@
-class ArtistSerializer < ActiveModel::Serializer
+class ArtistSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :artist
+  cache_options enabled: true, cache_length: 1.hour
   attributes :name, :bio, :birthdate, :alter_name
-  has_many :songs
-  has_many :bands
+  has_many :songs, record_type: :song
+  has_many :bands, record_type: :band
+  has_many :albums, record_type: :album
 end

--- a/app/serializers/band_serializer.rb
+++ b/app/serializers/band_serializer.rb
@@ -1,5 +1,8 @@
-class BandSerializer < ActiveModel::Serializer
+class BandSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :band
+  cache_options enabled: true, cache_length: 1.hour
   attributes :name, :bio, :start_date, :end_date
-  has_many :albums
-  has_many :songs
+  has_many :albums, record_type: :album
+  has_many :songs, record_type: :song
 end

--- a/app/serializers/playlist_serializer.rb
+++ b/app/serializers/playlist_serializer.rb
@@ -1,4 +1,7 @@
-class PlaylistSerializer < ActiveModel::Serializer
+class PlaylistSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :playlist
+  cache_options enabled: true, cache_length: 1.hour
   attributes :name, :author, :date
-  has_many :songs
+  has_many :songs, record_type: :song
 end

--- a/app/serializers/song_serializer.rb
+++ b/app/serializers/song_serializer.rb
@@ -1,4 +1,9 @@
-class SongSerializer < ActiveModel::Serializer
-  attributes :name, :duration, :date, :author
-  belongs_to :author
+class SongSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :song
+  cache_options enabled: true, cache_length: 1.hour
+  attributes :name, :duration, :date
+  belongs_to :author, polymorphic: { Artist: :artist, Band: :band }
+  has_many :playlists, record_type: :playlist
+  has_many :albums, record_type: :album
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,21 +1,23 @@
 require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-require "action_cable/engine"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
+require 'action_cable/engine'
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+Dotenv::Railtie.load
 
 module Ipsyapi
   class Application < Rails::Application

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,13 +2,13 @@ default: &default
   adapter: mysql2
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: ipsyMusicIsTheBest
-  host: db
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  host: <%= ENV['DB_HOST'] %>
 
 development:
   <<: *default
-  database: ipsy_music_db
+  database: <%= ENV['DB_NAME'] %>
 
 
 test:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,16 +1,23 @@
+# frozen_string_literal: true
+
 Artist.reindex
 Album.reindex
 Song.reindex
 Playlist.reindex
-artists = FactoryBot.create_list(:artist, 100)
+Band.reindex
+puts "Creating Artists"
+artists = FactoryBot.create_list(:artist, 50)
 artists.each do |art|
+  puts "creating Songs and Albums for Artist: #{art.id}"
   10.times do
     album = FactoryBot.create(:album, author: art)
     songs = FactoryBot.create_list(:song, 10, author: art)
     album.songs << songs
   end
 end
+puts "Creating playlists"
 playlists = FactoryBot.create_list(:playlist, 100)
 playlists.each do |playl|
-  playl.songs << Song.order("RAND()").limit(10)
+  puts "Adding songs to playlist #{playl.id}"
+  playl.songs << Song.order('RAND()').limit(10)
 end

--- a/spec/controllers/albums_controller_spec.rb
+++ b/spec/controllers/albums_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AlbumsController, type: :controller do
       get :index, params: { term: album.name }, session: valid_session
       json_response = JSON.parse(response.body)
       expect(response).to be_successful
-      expect(json_response.count).to eq(1)
+      expect(json_response["meta"]["total"]).to eq(1)
     end
   end
 


### PR DESCRIPTION
Replaced `active model serializers` with `fast_jsonapi` from Netflix. Reduced the response time for 1000 records from 4 seconds to 0.4. Addopted the jsonapi response to prevent duplications in code.

Added a cache strategy for 1 hour.

Cache strategies might work fine in systems with low record updates/creations. As Music is one if this business areas, we can cache everything but the playlists, I still cached the lists and future improvements might aim to refresh the list cache when the list is updated.